### PR TITLE
Add wen.pm

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -453,6 +453,7 @@ Tools to help you build on Cardano:
 - [Voting by Dust](https://vote.crypto2099.io/)
 - [Python LeaderLog and getSigma scripts]()
 - [JorManager](https://bitbucket.org/muamw10/jormanager/src/develop/)
+- [wen.pm timelines to significant Cardano News](https://wen.pm)
 
 ### 🧑‍🏫 Community Training 🧑‍🏫 ###
 - [Lovelace academy](https://lovelace.academy/)


### PR DESCRIPTION
wen.pm tracks the most significant events in the Cardano ecosystem and gives visitors a fast and easy way to find what's coming up in their favorite blockchain.