### PR TITLE
Update essential-cardano-list.md

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -237,7 +237,7 @@ These materials have been produced by the Plutus Pioneer course participants:
 - [Blockfrost.io](https://blockfrost.io)
 
 ### Native Tokens ###
-- [Native tokens explainer](https://docs.cardano.org/en/latest/native-tokens/learn-about-native-tokens.html)
+- [Native tokens explainer](https://docs.cardano.org/native-tokens/learn)
 - [Native tokens explainer video](https://www.youtube.com/watch?v=PVqsCXh-V5Y)
 
 ## Wallets ##


### PR DESCRIPTION
I found a 404 on the NFT Section. The NFT Explainer Link. I corrected it. It was pointing to: https://docs.cardano.org/en/latest/native-tokens/learn-about-native-tokens.html The fix has it pointing to: https://docs.cardano.org/native-tokens/learn