### PR TITLE
Update Coti.io url on essential-cardano-list as current one broken

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -160,7 +160,7 @@ Here is a map of our vibrant ecosystem (April 2021) - new version coming soon:
 - [Gate.io](https://www.gate.io/)
 
 ## Payments ##
-- [Coti](coti.io)
+- [Coti]((https://coti.io)
 - [Sirin Labs](https://sirinlabs.com/)
 - [Metaps+](https://metaps.com/)
 - AdaPay


### PR DESCRIPTION
Fix Coti.Io url as protocol was missing and link was broken.