### PR TITLE
Added entry for PIGY Oracle, in the Oracles section.

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -46,6 +46,7 @@ Here is an outline of the categories:
 - [WolframAlpha](https://www.wolframalpha.com/)
 - [nut.link](https://nut.link/)
 - [Charli3](https://charli3.io/)
+- [PIGY](https://oracle.pigytoken.com/)
 
 ## Enterprise & Business Ecosystem ##
 


### PR DESCRIPTION
The PIGY Oracle is a minimal-cost, community-driven oracle to benefit the small stakepools that distribute the PIGY token. It has been live on Alonzo Purple, is running on `testnet`, and will launch on `mainnet` at the Alonzo hard fork.