### PR TITLE
Add Cardano Jobs to List

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -649,6 +649,7 @@ Tools to help you build on Cardano:
 - [Cardano Token Tool](https://tokentool.io/)
 - [Cardano Client Lib Java Library](https://github.com/bloxbean/cardano-client-lib)
 - [.NET Cryptographic and Serialization Library](https://github.com/CardanoSharp/cardanosharp-wallet)
+- [Cardano Jobs](https://cardanojobs.io)
 
 ### Our Essential Community Top Five ###
 - [New to Cardano guide](https://static.adapools.org/docs/newbie-ultimate-guide.pdf)


### PR DESCRIPTION
I would like to add the job board Cardano Jobs which is a custom job board for any employers and employees that are building on Cardano. 

I have put it in Builder Tools but maybe you can think of a better place to put it. Happy to take suggestions. 

Thanks 