### PR TITLE
Add Tili.Gallery under NFT platforms

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -1025,6 +1025,7 @@ Tools to help you build on Cardano:
 - [Pergamon App](https://pergamon.app)
 - [Fort Gotten](https://www.fort-gotten.com/)
 - [The Burrow NFT](https://www.theburrownft.art/)
+- [Tili.Gallery](https://tili.gallery/)
 
 ## 🥩 Stake Pools 🥩 ##
 


### PR DESCRIPTION
This PR adds [Tili.Gallery](https://tili.gallery/) under NFT platforms.