### PR TITLE
Rebranding to AdaMuesliSwap

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -168,6 +168,7 @@ Here is an outline of the categories:
 
 ## Decentralized Exchanges (DEXs) ##
 - [Adax](https://adax.pro/)
+- [AdaMuesliSwap](https://ada.muesliswap.com/)
 - [Cardax](https://cardax.io/)
 - [CardStarter](https://www.cardstarter.io/)
 - [ErgoDex](https://ergodex.io/)
@@ -175,7 +176,6 @@ Here is an outline of the categories:
 - [Maladex](https://maladex.com/) 
 - [Minswap](https://minswap.org/)
 - [Mirqur](https://mirqur.io/)
-- [MuesliSwap](https://ada.muesliswap.com/)
 - [Occam](https://occam.fi/)
 - [Polyswap](https://polyswap.io/)
 - [Ravendex](https://ravendex.io/)


### PR DESCRIPTION
There has been considerable confusion regarding the co-existance of the two DEX projects MuesliSwap for SmartBCH (https://bch.muesliswap.com) and MuesliSwap for Cardano (https://ada.muesliswap.com). Therefore, the DEX will from now on be using the name "AdaMuesliSwap" when referring to the Cardano branch of the DEX project.
This rebranding should also be reflected in this list.