### PR TITLE
Add Atomic Swap

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -210,6 +210,7 @@ Here is an outline of the categories:
 - [Ada Blobs](https://adablobs.io/)
 - [DripDropz](https://dripdropz.io/)
 - [Martify](https://martify.io/)
+- [Atomic Swap](https://atomic-swap.io/)
 - [Trading Tent](https://www.tradingtent.io/)
 - [Cardahub](https://cardahub.io/home)
 


### PR DESCRIPTION
Atomic Swap is a non-escrow escrow (allow 2 people to trade any number of assets against any other number of assets) and is similar to Trading Tent.