### PR TITLE
Removed the evidently Scam DEX ravendex.io

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -202,7 +202,6 @@ Here is an outline of the categories:
 - [MuesliSwap](https://ada.muesliswap.com/)
 - [Occam](https://occam.fi/)
 - [Polyswap](https://polyswap.io/)
-- [Ravendex](https://ravendex.io/)
 - [Ray Network](https://rraayy.com/)
 - [Sundaeswap](https://www.sundaeswap.finance/)
 - [Thothus](https://thothus.io)


### PR DESCRIPTION
The detailed evidence is found here:

- https://builtoncardano.com/blog/ravendex-a-scam-an-investment-opportunity-or-just-another-dex 
- https://forum.cardano.org/t/ravendex/78786/8
- https://www.scamdoc.com/view/674822
- https://www.reddit.com/r/CryptoCurrency/comments/qfl435/a_word_of_warning_about_ravendex_my_experiences/?utm_source=share&utm_medium=web2x&context=3