### PR TITLE
MetaLamp URL-address update

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -91,7 +91,7 @@ Here is an outline of the categories:
 - [Indigo](https://indigoprotocol.io/)
 - [Konfidio](https://konfidio.com/)
 - [LunaTech](https://lunatech.com/)
-- [Metalamp](https://en.metalamp.io/)
+- [Metalamp](https://www.metalamp.io/)
 - [Mlabs](https://mlabs.city/)
 - [Mukn](https://mukn.io/)
 - [Ncube](https://ncube.com/)


### PR DESCRIPTION
The MetaLamp team has a new URL.