### PR TITLE
Remove GOADA Decentralized exchange

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -195,7 +195,6 @@ Here is an outline of the categories:
 - [DOEX](https://www.doex.org/)
 - [ErgoDex](https://ergodex.io/)
 - [GADA](https://gada.finance/)
-- [GOADA](https://goada.net/)
 - [Maladex](https://maladex.com/) 
 - [Meowswap](https://meowswap.fi/)
 - [Minswap](https://minswap.org/)


### PR DESCRIPTION
I'm here to ask to remove GOADA from the decentralized exchange list.

While at one point it was running on testnet we had some problems and the team broke up.

GOADA is going to close and never see mainnet.