### PR TITLE
Project Flickto ceased operations.

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -238,7 +238,6 @@ Here is an outline of the categories:
 - DC-fund
 - [Defipronto](https://defipronto.com/)
 - [Dlab](https://dlab.vc/)
-- [Flickto](https://www.flickto.io/)
 - [Project Catalyst](https://cardano.ideascale.com/a/index)
 - Treasury Wave
 - [Y2X](https://y2x.io/)  


### PR DESCRIPTION
According to their website:
The Flickto project ceased operations on the 19th May 2022. The legal entity behind Flickto (Flickto LTD) is about to go through an insolvent liquidation.