### PR TITLE
Add Haltscam project

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -471,6 +471,7 @@ These materials have been produced by the Plutus Pioneer course participants:
 - [Milkomeda](http://milkomeda.com)
 
 ### Abuse Detection & Prevention ###
+- [haltscam](https://haltscam.com/)
 - [Cardano Phishing Bot](https://twitter.com/CardanoPhishing)
 
 ## Project Catalyst Startups ##


### PR DESCRIPTION
Haltscam allows and provides a means of crowd-sourcing risky Cardano addresses, allowing community members to contribute to the database and prevent their fellow adopters from falling victim to scams or solicitation.
> Thanks to the work we are doing in Haltscam we got CF delegation.