### PR TITLE
Remove PIGY Oracle from Essential Cardano

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -50,7 +50,6 @@ Here is an outline of the categories:
 - [Ergo](https://ergoplatform.org/en/)
 - [Charli3](https://charli3.io/)
 - [nut.link](https://nut.link/)
-- [PIGY](https://oracle.pigytoken.com/)
 - [WolframAlpha](https://www.wolframalpha.com/)
 
 ## Enterprise & Business Ecosystem ##


### PR DESCRIPTION
I'm retiring the PIGY Oracle at the end of the Alonzo era, so I recommend removing it from the Essential Cardano list (and other tabulations maintained by IOG). Thank you.