### PR TITLE
Remove soon-obsolete min-Ada calculator

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -395,7 +395,6 @@ These materials have been produced by the Plutus Pioneer course participants:
 - [ada calculator](https://adacalculator.com/)
 - [ADA Calculators - MajorPool.net](https://majorpool.net/calculators)
 - [Cardano ADA Gainz calculator](https://cardanogainz.com)
-- [Min ada calculator](https://mantis.functionally.io/how-to/min-ada-value/)
 - [Crypto and Cardano market projection tool](https://cardanolatino.com/cardanoenglish/staking-calculator/)
 - [The ADAlator](https://adalator.com/)
 


### PR DESCRIPTION
The min-Ada calculator will become obsolete in the Babbage era because the ledger's min-UTxO calculation is different there compared to previously. Thank you.