### PR TITLE
Add Adadao in Essential Cardano List

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -229,6 +229,7 @@ Here is an outline of the categories:
 - [Sirin Labs](https://sirinlabs.com/)
 - [WooCommerce](https://woocommerce.com/)
 - [NMKR Pay](https://www.nmkr.io/pay)
+- [Adadao](https://adadao.org)
 
 ### Incubators and Funding ###
 - [C-fund](https://cfund.vc/)


### PR DESCRIPTION
Update essential-cardano-list.md to add Adadao in the "Payment and Lending" section of Essential Cardano list.