### PR TITLE
Add Chain49 to list of infra providers

### DIFF
--- a/essential-cardano-list.md
+++ b/essential-cardano-list.md
@@ -478,6 +478,7 @@ These materials have been produced by the Plutus Pioneer course participants:
 - [Dandelion](https://gimbalabs.com/gimbalgrid/9)
 - [NMKR Studio](https://www.nmkr.io/studio)
 - [NOWNodes - free API key](http://bit.do/nownodes-cardano)
+- [Chain49](https://chain49.com/)
 
 ### Audits ###
 - [Quantstamp](https://quantstamp.com/)


### PR DESCRIPTION
Hello!

I represent Chain49.com and have added a link to our website to the list.

We offer free and instant access to our shared blockchain API supporting most popular chains which includes access to Cardano Mainnet, Pre-Prod and Preview via Rosetta API (cardano-rosetta).

I hope everything is in order and we look forward to be added to the official list!

Thank you and kind regards